### PR TITLE
Configure iOS App Store deployment with EAS

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,7 +10,10 @@
     "newArchEnabled": true,
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.anonymous.pali-me"
+      "bundleIdentifier": "com.palime.palime",
+      "infoPlist": {
+        "ITSAppUsesNonExemptEncryption": false
+      }
     },
     "android": {
       "adaptiveIcon": {
@@ -44,6 +47,12 @@
     "experiments": {
       "typedRoutes": true,
       "reactCompiler": true
+    },
+    "extra": {
+      "router": {},
+      "eas": {
+        "projectId": "71630df0-7756-474a-877a-bfc7d05b5916"
+      }
     }
   }
 }

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,21 @@
+{
+  "cli": {
+    "version": ">= 18.4.0",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {
+      "autoIncrement": true
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "test:coverage": "jest --coverage",
     "pre-commit": "pnpm format && pnpm lint && pnpm test",
     "maestro": "maestro test .maestro",
-    "maestro:ios": "maestro test .maestro --format junit --output maestro-results-ios.xml"
+    "maestro:ios": "maestro test .maestro --format junit --output maestro-results-ios.xml",
+    "build:ios": "eas build --platform ios --profile production",
+    "submit:ios": "eas submit --platform ios"
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",


### PR DESCRIPTION
## Summary

Configure pali-me for iOS App Store deployment using EAS Build and EAS Submit. This includes updating the bundle identifier, adding encryption compliance settings, creating the EAS configuration file, and adding convenience npm scripts for the build and submission workflow.

## Changes

- **app.json**: Update bundle identifier to `com.palime.palime` and add `ITSAppUsesNonExemptEncryption: false` flag for US export compliance (standard HTTPS-only encryption)
- **eas.json**: Add EAS Build/Submit configuration with development, preview, and production build profiles
- **package.json**: Add `build:ios` and `submit:ios` scripts to streamline the iOS deployment workflow

## Why

These changes enable the app to be built and submitted to the Apple App Store using Expo's EAS platform, which handles code signing, provisioning profiles, and certificate management automatically. The bundle identifier change from the placeholder `com.anonymous.pali-me` allows the app to be registered in App Store Connect.

## Testing

- EAS CLI was initialized successfully with the configuration
- Build process was started and encryption compliance questions answered
- All changes are configuration-only and do not affect app functionality

## Notes for Reviewers

- The EAS project ID was auto-generated during `eas build:configure`
- The bundle identifier `com.palime.palime` must be registered in App Store Connect before builds can be submitted
- The build and submit scripts can be run locally with `pnpm build:ios` and `pnpm submit:ios`